### PR TITLE
Replaced json storage in redis with msgpack.

### DIFF
--- a/nupic_history/sp_redis_client.py
+++ b/nupic_history/sp_redis_client.py
@@ -1,6 +1,6 @@
 import sys
 import time
-import msgpack as json
+import msgpack
 
 import redis
 
@@ -31,7 +31,7 @@ class SpRedisClient(object):
 
 
   def listSpIds(self):
-    return json.loads(self._redis.get(self.SP_LIST))["sps"]
+    return msgpack.loads(self._redis.get(self.SP_LIST))["sps"]
 
 
   def saveSpState(self, spHistory):
@@ -75,7 +75,7 @@ class SpRedisClient(object):
     spList = rds.get(self.SP_LIST)
     deleted = 0
     if spList is not None:
-      spList = json.loads(spList)["sps"]
+      spList = msgpack.loads(spList)["sps"]
       for spid in spList:
         deleted += self.delete(spid)
       deleted += rds.delete(self.SP_LIST)
@@ -90,16 +90,16 @@ class SpRedisClient(object):
     for key in doomed:
       deleted += rds.delete(key)
     # Also remove the registry entry
-    spList = json.loads(rds.get(self.SP_LIST))
+    spList = msgpack.loads(rds.get(self.SP_LIST))
     sps = spList["sps"]
     doomed = sps.index(spid)
     del sps[doomed]
-    rds.set(self.SP_LIST, json.dumps(spList))
+    rds.set(self.SP_LIST, msgpack.dumps(spList))
     return deleted
 
 
   def getSpParams(self, spid):
-    params = json.loads(self._redis.get(self.SP_PARAMS.format(spid)))
+    params = msgpack.loads(self._redis.get(self.SP_PARAMS.format(spid)))
     return params["params"]
 
 
@@ -112,21 +112,21 @@ class SpRedisClient(object):
 
   def getLayerState(self, spid, stateType, iteration):
     state = self._redis.get(self.GLOBAL_VALS.format(spid, iteration, stateType))
-    return json.loads(state)[stateType]
+    return msgpack.loads(state)[stateType]
 
 
   def getPerColumnState(self, spid, stateType, iteration, numColumns):
     out = []
     for columnIndex in xrange(0, numColumns):
       key = self.COLUMN_VALS.format(spid, iteration, columnIndex, stateType)
-      column = json.loads(self._redis.get(key))
+      column = msgpack.loads(self._redis.get(key))
       out.append(column[stateType])
     return out
 
 
   def getPotentialPools(self, spid):
     pools = self._redis.get(self.SP_POT_POOLS.format(spid))
-    return json.loads(pools)
+    return msgpack.loads(pools)
 
 
   def _saveSpLayerValues(self, state, spid, iteration):
@@ -183,7 +183,7 @@ class SpRedisClient(object):
     if spList is None:
       spList = {"sps": [spid]}
     else:
-      spList = json.loads(spList)
+      spList = msgpack.loads(spList)
       if spid not in spList["sps"]:
         spList["sps"].append(spid)
     self._saveObject(self.SP_LIST, spList)
@@ -196,7 +196,7 @@ class SpRedisClient(object):
 
   def _saveObject(self, key, obj):
     # Using explicit separators keeps unnecessary whitespace out of Redis.
-    jsonString = json.dumps(obj)
-    size = sys.getsizeof(jsonString)
-    self._redis.set(key, jsonString)
+    msgpackString = msgpack.dumps(obj)
+    size = sys.getsizeof(msgpackString)
+    self._redis.set(key, msgpackString)
     return size

--- a/nupic_history/sp_redis_client.py
+++ b/nupic_history/sp_redis_client.py
@@ -1,6 +1,6 @@
 import sys
 import time
-import json
+import msgpack as json
 
 import redis
 
@@ -196,7 +196,7 @@ class SpRedisClient(object):
 
   def _saveObject(self, key, obj):
     # Using explicit separators keeps unnecessary whitespace out of Redis.
-    jsonString = json.dumps(obj, separators=(',',':'))
+    jsonString = json.dumps(obj)
     size = sys.getsizeof(jsonString)
     self._redis.set(key, jsonString)
     return size

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ nupic.bindings==0.4.5.dev0
 redis==2.10.5
 web.py==0.38
 wsgiref==0.1.2
+msgpack-python==0.4.1

--- a/test1.py
+++ b/test1.py
@@ -75,21 +75,21 @@ def runFetchTest(spid):
     print "Can't save inactive facade."
 
   start = time.time()
-
+  iterations = sp.getIteration() + 1
   # We can playback the life of the SP.
-  for i in range(0, sp.getIteration() + 1):
-    print "\niteration {}".format(i)
-    print sp.getState(SpSnapshots.INPUT, iteration=i).keys()
-    print sp.getState(SpSnapshots.ACT_COL, iteration=i).keys()
-    print sp.getState(SpSnapshots.POT_POOLS, iteration=i).keys()
-    print sp.getState(SpSnapshots.OVERLAPS, iteration=i).keys()
-    print sp.getState(SpSnapshots.PERMS, iteration=i).keys()
-    print sp.getState(SpSnapshots.ACT_DC, iteration=i).keys()
-    print sp.getState(SpSnapshots.OVP_DC, iteration=i).keys()
-    print sp.getState(SpSnapshots.CON_SYN, iteration=i).keys()
+  for i in range(0, iterations):
+    # print "\niteration {}".format(i)
+    sp.getState(SpSnapshots.INPUT, iteration=i)
+    sp.getState(SpSnapshots.ACT_COL, iteration=i)
+    sp.getState(SpSnapshots.POT_POOLS, iteration=i)
+    sp.getState(SpSnapshots.OVERLAPS, iteration=i)
+    sp.getState(SpSnapshots.PERMS, iteration=i)
+    sp.getState(SpSnapshots.ACT_DC, iteration=i)
+    sp.getState(SpSnapshots.OVP_DC, iteration=i)
+    sp.getState(SpSnapshots.CON_SYN, iteration=i)
 
   end = time.time()
-  print "\nRETRIEVAL: {} iterations took {} seconds.".format(sp.getIteration(), (end - start))
+  print "\nRETRIEVAL: {} iterations took {} seconds.".format(iterations, (end - start))
 
 if __name__ == "__main__":
   spid = runSaveTest()


### PR DESCRIPTION
Fixes #2.

Thanks for the suggestion, @oxtopus. I found that `msgpack` speeds things up, even though the storage size is larger. The numbers below are from running the `test1.py` script.
## `json`

```
STORAGE: 10 iterations took 8.65475797653 seconds.
RETRIEVAL: 10 iterations took 6.58692598343 seconds.
used_memory_human: 54.96M
```
## `msgpack`

```
STORAGE: 10 iterations took 5.65669083595 seconds.
RETRIEVAL: 10 iterations took 4.86526799202 seconds.

used_memory_human: 114.64M
```
