### PR TITLE
Fix bug in _conjureActiveColumns

### DIFF
--- a/nupic_history/sp_facade.py
+++ b/nupic_history/sp_facade.py
@@ -278,7 +278,7 @@ class SpFacade(object):
       out = compressSdr(self._activeColumns)
     else:
       if columnIndex is None:
-        out = self._redisClient.getLayerState(
+        out = self._redisClient.getLayerStateByIteration(
           self.getId(), SNAPS.ACT_COL, iteration
         )
       else:


### PR DESCRIPTION
@rhyolight 

I encountered the following error while running the example code in nupic-history-server. It looks like a bug in _conjureActiveColumns. I tried to fix it here.

![image](https://cloud.githubusercontent.com/assets/5067931/18022433/c35d32e2-6ba3-11e6-81d0-2271e16a7846.png)
